### PR TITLE
Update resultsmodel.cpp

### DIFF
--- a/src/model/resultsmodel.cpp
+++ b/src/model/resultsmodel.cpp
@@ -38,7 +38,7 @@ public:
         : QSortFilterProxyModel(parent)
     {
         setDynamicSortFilter(true);
-        sort(0, Qt::DescendingOrder);
+        sort(0, Qt::AscendingOrder);
     }
 
     void setQueryString(const QString &queryString)


### PR DESCRIPTION
I don't know who thought this is a good decision, but it's really strange to search for something and the results are sorted alphabetically but descending. It's such a strange feeling.

Example:
<img width="595" height="428" alt="image" src="https://github.com/user-attachments/assets/dfc39a3e-cb8a-4fc5-b009-e307e4596f86" />
How is "system sounds" before "screen edges" or "sensors before samba".

<img width="588" height="182" alt="image" src="https://github.com/user-attachments/assets/c7427cbd-0634-4b75-a546-7255ca9c31a3" />

By this point if ascending sorting pressing enter will get you into discord which makes logical sense but because it's descending you have to write until it gets to "discor"